### PR TITLE
Graph API service comms

### DIFF
--- a/WellArchitectedFramework/Reliability/samples/ServiceCommsAwareness/Graph API Queries/Service Announcement Messages.txt
+++ b/WellArchitectedFramework/Reliability/samples/ServiceCommsAwareness/Graph API Queries/Service Announcement Messages.txt
@@ -1,0 +1,2 @@
+Filter messages to Dynamics 365 since 07-01-2024
+https://graph.microsoft.com/v1.0/admin/serviceAnnouncement/messages?$filter=services/any(i:i eq 'Dynamics CRM') and startDateTime ge 2024-07-01

--- a/WellArchitectedFramework/Reliability/samples/ServiceCommsAwareness/Graph API Queries/Service Health Overview.txt
+++ b/WellArchitectedFramework/Reliability/samples/ServiceCommsAwareness/Graph API Queries/Service Health Overview.txt
@@ -1,0 +1,8 @@
+Filter to only Dynamics 365 
+https://graph.microsoft.com/v1.0/admin/serviceAnnouncement/healthOverviews?$filter=id eq 'DynamicsCRM'
+
+Filter to only Power Apps
+https://graph.microsoft.com/v1.0/admin/serviceAnnouncement/healthOverviews?$filter=id in 'PowerApps'
+
+Filter to all Power Platform and related workloads including Microsoft Entra
+https://graph.microsoft.com/v1.0/admin/serviceAnnouncement/healthOverviews?$filter=id in ('DynamicsCRM','DynamicsAX','PowerApps','MicrosoftFlow','PowerAppsM365','MicrosoftFlowM365','PowerPlatform','Copilot','PowerBIcom','OrgLiveID')

--- a/WellArchitectedFramework/Reliability/samples/ServiceCommsAwareness/Graph API Queries/Service Issues.txt
+++ b/WellArchitectedFramework/Reliability/samples/ServiceCommsAwareness/Graph API Queries/Service Issues.txt
@@ -1,0 +1,2 @@
+Filter issues to Dynamics 365
+https://graph.microsoft.com/v1.0/admin/serviceAnnouncement/issues?$filter=service eq 'Dynamics 365 Apps'


### PR DESCRIPTION
This commit contains REST examples for the Graph API related to service comms. These can be used for alerts and dashboards.